### PR TITLE
ROC read fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ cmake_minimum_required (VERSION 3.19 FATAL_ERROR)
 
 find_package(cetmodules 3.16.00 REQUIRED)
 
-project(otsdaq_mu2e_crv VERSION 1.03.02)
+project(otsdaq_mu2e_crv VERSION 1.04.00)
 
 include(CetCMakeEnv)
 cet_cmake_env()

--- a/otsdaq-mu2e-crv/FEInterfaces/ROCCosmicRayVetoInterface.h
+++ b/otsdaq-mu2e-crv/FEInterfaces/ROCCosmicRayVetoInterface.h
@@ -45,6 +45,8 @@ public:
 
 	virtual int  							readDTCLinkLossCounter	(void) override;
 	virtual void 							resetDTCLinkLossCounter	(void) override;
+	virtual void							GetStatus				(void) override { return; }
+	virtual void							GetFirmwareVersion		(void) override { return; }
 
 
 public:

--- a/otsdaq-mu2e-crv/FEInterfaces/ROCCosmicRayVetoInterface.h
+++ b/otsdaq-mu2e-crv/FEInterfaces/ROCCosmicRayVetoInterface.h
@@ -31,19 +31,19 @@ public:
 	bool 									running					(void) override;	
 
 	// write and read to registers
-	virtual void 							writeROCRegister		(uint16_t address, uint16_t data_to_write) override;
-	virtual uint16_t  						readROCRegister			(uint16_t address) override;
+	// virtual void 							writeROCRegister		(uint16_t address, uint16_t data_to_write) override;
+	// virtual uint16_t  						readROCRegister			(uint16_t address) override;
 	virtual void 							writeEmulatorRegister	(uint16_t address, uint16_t data_to_write) override;
 	virtual uint16_t						readEmulatorRegister	(uint16_t address) override;
 
-	virtual void 							readROCBlock			(std::vector<uint16_t>& data, uint16_t address, uint16_t numberOfReads, bool incrementAddress) override { }
+	// virtual void 							readROCBlock			(std::vector<uint16_t>& data, uint16_t address, uint16_t numberOfReads, bool incrementAddress) override { }
 	virtual void 							readEmulatorBlock		(std::vector<uint16_t>& data, uint16_t address, uint16_t numberOfReads, bool incrementAddress) override { }
 
-    // used by slow controls
-	void 									universalRead				(char* address, char* readValue) override;
+	// used by slow controls
+	// void 									universalRead				(char* address, char* readValue) override;
 
 	// specific ROC functions
-	virtual int  							readTimestamp			(void) override;
+	virtual int  							readTimestamp (void); //  override; // build error with the override
 	virtual void 							writeDelay				(uint16_t delay) override;  // 5ns steps
 	virtual int  							readDelay				(void) override;            // 5ns steps
 

--- a/otsdaq-mu2e-crv/FEInterfaces/ROCCosmicRayVetoInterface_interface.cc
+++ b/otsdaq-mu2e-crv/FEInterfaces/ROCCosmicRayVetoInterface_interface.cc
@@ -1,5 +1,4 @@
 #include "otsdaq-mu2e-crv/FEInterfaces/ROCCosmicRayVetoInterface.h"
-
 #include "otsdaq/Macros/InterfacePluginMacros.h"
 
 using namespace ots;
@@ -105,44 +104,46 @@ ROCCosmicRayVetoInterface::~ROCCosmicRayVetoInterface(void)
 	__COUT__ << FEVInterface::interfaceUID_ << " Destructor" << __E__;
 }
 
-//==================================================================================================
-void ROCCosmicRayVetoInterface::writeROCRegister(uint16_t address, uint16_t data_to_write)
-{
-	__FE_COUT__ << "Calling write CRV-ROC register: link number " << std::dec << (int)linkID_
-	            << ", address = " << address << ", write data = " << data_to_write
-	            << __E__;
+// //==================================================================================================
+// void ROCCosmicRayVetoInterface::writeROCRegister(uint16_t address, uint16_t data_to_write)
+// {
+// 	__FE_COUT__ << "Calling write CRV-ROC register: link number " << std::dec << (int)linkID_
+// 	            << ", address = " << address << ", write data = " << data_to_write
+// 	            << __E__;
 
-    roc_.writeRegister(address, data_to_write);
-	//thisDTC_->WriteROCRegister(linkID_, address, data_to_write,
-	//							false, 0 //requestAck, ack_tmo_ms
-	//							);
+//     roc_.writeRegister(address, data_to_write);
+// 	//thisDTC_->WriteROCRegister(linkID_, address, data_to_write,
+// 	//							false, 0 //requestAck, ack_tmo_ms
+// 	//							);
 
-	return;
-}
+// 	return;
+// }
 
-void ROCCosmicRayVetoInterface::universalRead(char* address, char* readValue) {
-	__FE_COUT__ << "CRV ROC universalRead: ";
-	uint16_t data = roc_.readRegister(*address);
-	__FE_COUT__ << data << __E__;
-	readValue[0] = 0x12;
-	readValue[1] = 0x34;
-}
+// //==================================================================================================
+// void ROCCosmicRayVetoInterface::universalRead(char* address, char* readValue) 
+// {
+// 	__FE_COUT__ << "CRV ROC universalRead: ";
+// 	uint16_t data = roc_.readRegister(*address);
+// 	__FE_COUT__ << data << __E__;
+// 	readValue[0] = 0x12;
+// 	readValue[1] = 0x34;
+// }
 
-//==================================================================================================
-uint16_t ROCCosmicRayVetoInterface::readROCRegister(uint16_t address)
-{
-	__FE_COUT__ << "Calling read CRV ROC register: link number " << std::dec << linkID_
-	            << ", address = " << address << __E__;
+// //==================================================================================================
+// uint16_t ROCCosmicRayVetoInterface::readROCRegister(uint16_t address)
+// {
+// 	__FE_COUT__ << "Calling read CRV ROC register: link number " << std::dec << linkID_
+// 	            << ", address = " << address << std::hex << " 0x" << address << __E__;
 
-        return roc_.readRegister(address);
-		//return thisDTC_->ReadROCRegister(linkID_, address, tmo_ms_);
-} 
+// 	return roc_.readRegister(address);
+// 	//return thisDTC_->ReadROCRegister(linkID_, address, tmo_ms_);
+// } 
 
 //============================================================================================
 void ROCCosmicRayVetoInterface::writeEmulatorRegister(uint16_t address,
                                                       uint16_t data_to_write)
 {
-	__FE_COUT__ << "Calling write ROC Emulator register: link number " << std::dec
+	__FE_COUT__ << "Calling write CRV ROC Emulator register: link number " << std::dec
 	            << (int)linkID_ << ", address = " << address
 	            << ", write data = " << data_to_write << __E__;
 
@@ -152,7 +153,7 @@ void ROCCosmicRayVetoInterface::writeEmulatorRegister(uint16_t address,
 //==================================================================================================
 uint16_t ROCCosmicRayVetoInterface::readEmulatorRegister(uint16_t address)
 {
-	__FE_COUT__ << "Calling read ROC Emulator register: link number " << std::dec
+	__FE_COUT__ << "Calling read CRV ROC Emulator register: link number " << std::dec
 	            << (int)linkID_ << ", address = " << address << __E__;
 
 	return -1;

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -18,27 +18,26 @@ fcldir      fq_dir      fcl
 
 #
 product			version		optional
-otsdaq_mu2e		v1_03_02
-cetmodules		v3_21_02	-	only_for_build
+otsdaq_mu2e		v1_04_00
+cetmodules		v3_22_02	-	only_for_build
 end_product_list
 
 # -nq- here means there is no qualifier
 # a "-" here means the dependent product is not required by the parent and will not be setup
 qualifier		otsdaq_mu2e		notes
+e28:s126:prof	e28:s126:prof	-std=c++20
+e28:s126:debug	e28:s126:debug	-std=c++20
+e26:s126:prof	e26:s126:prof	-std=c++17
+e26:s126:debug	e26:s126:debug	-std=c++17
+e20:s126:prof	e20:s126:prof	-std=c++17
+e20:s126:debug	e20:s126:debug	-std=c++17
+
 e28:s124:prof	e28:s124:prof	-std=c++20
 e28:s124:debug	e28:s124:debug	-std=c++20
 e26:s124:prof	e26:s124:prof	-std=c++17
 e26:s124:debug	e26:s124:debug	-std=c++17
 e20:s124:prof	e20:s124:prof	-std=c++17
 e20:s124:debug	e20:s124:debug	-std=c++17
-
-e26:s123:prof	e26:s123:prof	-std=c++17
-e26:s123:debug	e26:s123:debug	-std=c++17
-e20:s123:prof	e20:s123:prof	-std=c++17
-e20:s123:debug	e20:s123:debug	-std=c++17
-
-e20:s112:prof	e20:s112:prof	-std=c++17
-e20:s112:debug	e20:s112:debug	-std=c++17
 end_qualifier_list
 
 # Preserve tabs and formatting in emacs and vi / vim:


### PR DESCRIPTION
The ROC read functions in `ROCCosmicRayVetoInterface` have been commented out, since these were overriding the base class functionality in `otsdaq-mu2e/ROCCore/ROCCoreVInterface`. This is the setup I have been using to successfully read the Wideband CRV ROC through otsdaq. These changes originally came from Ryan. 