### PR TITLE
Added standalone CRV data viewer / prototype artdaq DQM

### DIFF
--- a/otsdaq-mu2e-crv/ArtModules/CMakeLists.txt
+++ b/otsdaq-mu2e-crv/ArtModules/CMakeLists.txt
@@ -1,0 +1,18 @@
+include(BuildPlugins) 
+
+cet_build_plugin(CrvDQM art::module LIBRARIES REG
+    art_root_io::TFileService_service
+    artdaq_core_mu2e::artdaq-core-mu2e_Data
+    otsdaq_mu2e::otsdaq-mu2e_ArtModules
+    otsdaq::NetworkUtilities
+    ROOT::Hist
+    ROOT::Tree
+    ROOT::Core
+    ROOT::RIO
+    ROOT::Gui
+    ROOT::RHTTP 
+)
+
+install_headers(SUBDIRS detail)
+install_source(SUBDIRS detail)
+install_fhicl(SUBDIRS fcl)

--- a/otsdaq-mu2e-crv/ArtModules/CrvDQMStyle.hh
+++ b/otsdaq-mu2e-crv/ArtModules/CrvDQMStyle.hh
@@ -1,0 +1,91 @@
+// ROOT styling for CRV DQM 
+// Samuel Grant 2025
+
+#ifndef CRV_DQM_STYLE_H
+#define CRV_DQM_STYLE_H
+
+#include "TH1.h"
+#include "TH2.h"
+#include "TStyle.h"
+#include "TCanvas.h"
+#include "TPad.h"
+#include "TROOT.h"
+
+class CrvDQMStyle {
+public:
+    static void SetStyle() {
+
+        TStyle *style = new TStyle("CrvStyle", "CRV DQM styling");
+        
+        // Basic canvas settings
+        style->SetCanvasColor(kWhite);
+        style->SetCanvasBorderMode(0);
+        style->SetPadColor(kWhite);
+        style->SetPadBorderMode(0);
+        style->SetPadTopMargin(0.05);
+        style->SetPadBottomMargin(0.13);
+        style->SetPadLeftMargin(0.15);
+        style->SetPadRightMargin(0.05);
+        
+        // Font settings 
+        style->SetTextFont(42);
+        style->SetLabelFont(42, "xyz");
+        style->SetTitleFont(42, "xyz");
+        
+        // Text sizes
+        style->SetTextSize(0.045);
+        style->SetLabelSize(0.045, "xyz");
+        style->SetTitleSize(0.05, "xyz");
+        
+        // Title positioning
+        style->SetTitleOffset(1.2, "y");
+        style->SetTitleOffset(1.0, "x");
+
+        // Canvas fill
+        style->SetFillColor(kWhite);
+        style->SetFillStyle(1001);  
+        
+        // Ticks and divisions
+        style->SetPadTickX(1);
+        style->SetPadTickY(1);
+        style->SetTickLength(0.015);
+        style->SetNdivisions(505, "xyz");
+        
+        // Frame
+        style->SetFrameLineWidth(1);
+        style->SetLineWidth(1);
+        
+        style->SetOptStat(0);
+        
+        // Use current style - this works in 6.30
+        gROOT->SetStyle("CrvStyle");
+        gROOT->ForceStyle();
+    }
+
+    static void FormatHist(TH1* hist, const std::string& colour = "blue") {
+        if (!hist) return;
+        // Basic histogram-specific formatting 
+        hist->SetStats(0);
+        hist->SetLineWidth(2);
+        hist->SetFillStyle(1001);
+        hist->SetLineStyle(1);
+        hist->GetYaxis()->SetTitleOffset(1.6);
+        hist->GetXaxis()->SetTitleOffset(1.2);
+        
+        // Primary colours
+        if (colour == "blue") {
+            hist->SetLineColor(kAzure+2);
+            hist->SetFillColor(kAzure-9);
+        }
+        else if (colour == "green") {
+            hist->SetLineColor(kGreen+2);
+            hist->SetFillColor(kGreen-9);
+        }
+        else if (colour == "red") {
+            hist->SetLineColor(kRed+2);
+            hist->SetFillColor(kRed-9);
+        }
+    }
+};
+
+#endif

--- a/otsdaq-mu2e-crv/ArtModules/CrvDQM_module.cc
+++ b/otsdaq-mu2e-crv/ArtModules/CrvDQM_module.cc
@@ -1,0 +1,312 @@
+// ROOT-based DQM and viewer for the CRV 
+// Authors: Sam Grant and Simon Corrodi 
+// Data: Feb 2025
+
+// C++ includes
+#include <thread>
+
+// art includes
+#include "art/Framework/Core/EDAnalyzer.h"
+#include "art/Framework/Core/ModuleMacros.h"
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/Handle.h"
+#include "art/Framework/Principal/Run.h"
+
+// artdaq includes
+#include "artdaq-core/Data/ContainerFragment.hh"
+#include "artdaq-core/Data/Fragment.hh"
+#include "artdaq-core-mu2e/Data/CRVDataDecoder.hh"
+#include "artdaq-core-mu2e/Overlays/DTCEventFragment.hh"
+#include "artdaq-core-mu2e/Overlays/FragmentType.hh"
+
+// ROOT includes
+#include "TCanvas.h"
+#include "TH1D.h"
+#include "THttpServer.h"
+#include "TSystem.h"
+
+// Custom includes
+#include "CrvDQMStyle.hh"
+
+namespace demo { // what is the appropriate namespace?
+
+class CrvDQM : public art::EDAnalyzer {
+public:
+    // Constructor
+    explicit CrvDQM(fhicl::ParameterSet const& ps);
+    // Destructor
+    ~CrvDQM() override;
+
+private:
+    
+    // Functions
+    void beginJob() override;
+    void analyze(art::Event const& e) override;
+    void endJob() override;
+
+    // fcl parameters
+    int port_;
+    int diagLevel_;
+    float onlineRefreshPeriod_; 
+    bool keepAlive_; 
+    int keepAliveDuration_; // minutes
+    std::string histColor_; // "red"/"blue"/"green"
+
+    // Member variables
+    TCanvas* canvas_;
+    std::unordered_map<std::string, TH1D*> hists_;
+    THttpServer* server_;
+    std::chrono::time_point<std::chrono::steady_clock> lastUpdate_;
+    std::size_t eventCounter_;
+    std::thread keepAliveThread_;  
+
+};
+
+// Constructor implementation
+CrvDQM::CrvDQM(fhicl::ParameterSet const& ps)
+    : art::EDAnalyzer(ps)
+    , port_(ps.get<int>("port", 8877))
+    , diagLevel_(ps.get<int>("diagLevel", 1))
+    , onlineRefreshPeriod_(ps.get<float> ("onlineRefreshPeriod", 500)) // ms
+    , keepAlive_(ps.get<int> ("keepAlive", true))
+    , keepAliveDuration_(ps.get<int> ("keepAliveDuration", 5)) // minutes
+    , histColor_(ps.get<std::string> ("histColor", "blue")) // minutes
+{
+    // Initialise non-fcl member variables
+    eventCounter_ = 0;
+}
+
+// Destructor implementation
+CrvDQM::~CrvDQM() {
+    // Make sure the server thread is stopped
+    if(keepAliveThread_.joinable()) {
+        keepAliveThread_.join();
+    }
+    // Then clean up ROOT objects
+    if (server_) {
+        delete server_; 
+        server_ = nullptr;
+    }
+    if (canvas_) {
+        delete canvas_;
+        canvas_ = nullptr;
+    }
+    for (auto& hist : hists_) {
+        if (hist.second) delete hist.second;
+        hist.second = nullptr;
+    }
+    hists_.clear();
+}
+
+void CrvDQM::beginJob() {
+    // Create HTTP server
+    server_ = new THttpServer(Form("http:%d", port_));
+
+    // Set global plot style
+    CrvDQMStyle::SetStyle();    
+    
+    // Create canvas
+    std::string canvasName = "WebDisplay";
+    canvas_ = new TCanvas(canvasName.c_str(), "CRV web display"); 
+    canvas_->Divide(2,2); // divide into 4x4 grid
+    
+    // Create histograms
+    hists_["channels"] = new TH1D("Channels", ";Channel;Counts", 64, -0.5, 63.5);
+    hists_["timestamps"] = new TH1D("Timestamps", ";Timestamp;Counts", 256, 0, 255); // 0-0xff 
+    hists_["nhits"] = new TH1D("Hits", ";Hits / block;Counts", 61, 0, 60);
+    hists_["adc"] = new TH1D("ADC",";ADC;Counts", 201, -100, 100); 
+
+    // Format and draw
+    int canvasIdx = 1;
+    for (auto& hist : hists_) {
+        // Get pad 
+        canvas_->cd(canvasIdx);
+        ++canvasIdx;
+        // Consistent formatting
+        CrvDQMStyle::FormatHist(hist.second, histColor_);
+        // Draw
+        hist.second->Draw();
+    }
+
+    // Register with server
+    server_->Register("/", canvas_);
+
+    // Set item defaults
+    server_->SetItemField("/","_monitoring", Form("%f", onlineRefreshPeriod_)); // Update period 
+    server_->SetItemField("/","_sidebar", "0");
+    server_->SetItemField("/","_drawitem", canvasName.c_str()); // Set DQM canvas as default item
+    server_->SetItemField("/","_http_cache", "0");  // Disable HTTP caching
+
+    // Last update variable 
+    lastUpdate_ = std::chrono::steady_clock::now();
+
+    // Print URL
+    printf("Server running on http://localhost:%d/\n", port_);
+
+    // Start an independent thread for server
+    keepAliveThread_ = std::thread([this]() {
+        while(keepAlive_) {
+            gSystem->ProcessEvents(); // Process events
+            std::this_thread::sleep_for(std::chrono::milliseconds(100)); // Small sleep
+        }
+    });
+
+}
+
+void CrvDQM::analyze(art::Event const& e) {
+	// Get fragments 
+    std::vector<art::Handle<artdaq::Fragments> > fragmentHandles;
+    fragmentHandles = e.getMany<std::vector<artdaq::Fragment> >();
+    artdaq::FragmentPtrs containerFragments;
+    artdaq::Fragments fragments;
+
+    // Iterate through fragment handles
+	for (const auto& handle : fragmentHandles) {
+        // Catch invalid or empty handles
+        if (!handle.isValid() || handle->empty()) {
+	        continue;
+        }
+        // Check if the first object is Container Fragment
+        // ContainerFragment
+        // ├── Fragment 1 (DTCEVT)
+        // └── Fragment n (DTCEVT)
+        if (handle->front().type() == artdaq::Fragment::ContainerFragmentType) {
+            // Iterate through containers
+            for (const auto& cont : *handle) {
+                artdaq::ContainerFragment contf(cont);
+                // Break if this is single fragment rather than a container
+	            if (contf.fragment_type() != mu2e::FragmentType::DTCEVT) {
+                    break;
+                }
+                // Iterate through fragments in container and fill fragments vector
+                for (size_t i = 0; i < contf.block_count(); ++i) {
+                    containerFragments.push_back(contf[i]);
+                    fragments.push_back(*containerFragments.back());
+                }
+            }
+        } else { // If the first object in the handle a single fragment
+            if (handle->front().type() == mu2e::FragmentType::DTCEVT) {
+                // Iterate through fragments and fill fragments vector
+                for (auto frag : *handle) {
+                    fragments.emplace_back(frag);
+                }
+            }
+        }
+    }
+    if (diagLevel_ > 1) { 
+        TLOG(TLVL_INFO) << "[CrvDQM::analyze] Found nFragments" << fragments.size();
+    }
+
+    // Handle the fragments
+    for (const auto& frag : fragments) {
+        try {
+            mu2e::DTCEventFragment bb(frag); 
+            auto data = bb.getData(); 
+            auto event = &data; 
+            if (diagLevel_ > 1) { 
+                TLOG(TLVL_INFO) << "Event tag:\t" << "0x" << std::hex << std::setw(4) << std::setfill('0') << event->GetEventWindowTag().GetEventWindowTag(true);
+            }
+            DTCLib::DTC_EventHeader* eventHeader = event->GetHeader();
+            
+            if (diagLevel_ > 1) {
+                TLOG(TLVL_INFO) << eventHeader->toJson() << std::endl
+                << "Subevents count: " << event->GetSubEventCount() << std::endl;
+            }
+            
+            bool plotsUpdated = false;
+            for (unsigned int i = 0; i < event->GetSubEventCount(); ++i) { // In future, use GetSubsystemData to only get CRV subevents
+                DTCLib::DTC_SubEvent& subevent = *(event->GetSubEvent(i));
+                if (diagLevel_ > 1) {
+                    TLOG(TLVL_INFO) << "Subevent [" << i << "]:" << std::endl;
+                    TLOG(TLVL_INFO) << subevent.GetHeader()->toJson() << std::endl;
+                    TLOG(TLVL_INFO) << "Number of Data Block: " << subevent.GetDataBlockCount() << std::endl;
+                }
+                
+                for (size_t bl = 0; bl < subevent.GetDataBlockCount(); ++bl) {
+                    ++eventCounter_;
+                    auto block = subevent.GetDataBlock(bl);
+                    auto blockheader = block->GetHeader();
+                    if (diagLevel_ > 1) {
+                        TLOG(TLVL_INFO) << blockheader->toJSON() << std::endl;
+                        for (int ii = 0; ii < blockheader->GetPacketCount(); ++ii) {
+                            TLOG(TLVL_INFO) << DTCLib::DTC_DataPacket(((uint8_t*)block->blockPointer) + ((ii + 1) * 16)).toJSON() << std::endl;
+                        }
+                    }
+                    // Check if we want to decode this data block
+                    // Make sure we only process CRV data
+                    if(blockheader->GetSubsystem() == 0x2) { 
+                        if(blockheader->isValid()) {
+                            // DQM for version 0x0 data
+                            if( blockheader->GetVersion() == 0x0 ) {
+                                auto crvData = mu2e::CRVDataDecoder(subevent); // reference
+                                //const auto crvStatus = crvData.GetCRVROCStatusPacket(bl);
+                                auto hits = crvData.GetCRVHits(bl);
+                                for (auto& hit : hits) {
+                                    // Fill histograms
+                                    hists_["channels"]->Fill(hit.first.febChannel);
+                                    hists_["timestamps"]->Fill(hit.first.HitTime);
+                                    for (auto& adc : hit.second) {
+                                        hists_["adc"]->Fill(adc.ADC);
+                                    }
+                                }
+                                hists_["nhits"]->Fill(hits.size());
+                                plotsUpdated = true;
+                            }
+                        } else {
+                            // Iterate invalid count?
+                            // ++invalidEventCounter_;
+                            continue;
+                        }
+                    }
+                }
+            }
+
+            if(plotsUpdated) {
+                auto currentTime = std::chrono::steady_clock::now();
+                std::chrono::duration<double, std::milli> elapsed = currentTime - lastUpdate_;
+                if(elapsed.count() >= onlineRefreshPeriod_) {
+                    // Auto scale y-axis
+                    for (auto& hist : hists_) { 
+                        double maxContent =  hist.second->GetBinContent(hist.second->GetMaximumBin()); 
+                        hist.second->GetYaxis()->SetRangeUser(0, 1.15*maxContent);
+                    }
+                    // Update the canvas
+                    canvas_->Modified();
+                    canvas_->Update();
+                    gSystem->ProcessEvents(); // Update display
+                    lastUpdate_ = currentTime; // Update the time
+                }
+            }
+
+        }
+        catch (const std::exception& e) {
+            if (diagLevel_ > 0) {
+                TLOG(TLVL_WARNING) << "Error processing fragment: " << e.what();
+            }
+            continue;
+        }
+    }
+}
+
+// End job printouts
+void CrvDQM::endJob() {
+    // What am we defining as an "event"? Need to think about it.
+    printf("========================================\n");
+    printf("Processed Events  : %zu\n", eventCounter_);
+    // printf("Invalid Events    : %zu\n", invalidEventCounter_);
+    // printf("Valid Events      : %zu\n", eventCounter_ - invalidEventCounter_);
+    // printf("Error Rate        : %.2f%%\n", 
+    //      (eventCounter_ > 0) ? (100.0 * invalidEventCounter_ / eventCounter_) : 0.0);
+    if (keepAlive_) { 
+        printf("Keeping server alive for %i minutes", keepAliveDuration_);
+        printf("\n========================================\n");
+        std::this_thread::sleep_for(std::chrono::minutes(keepAliveDuration_));
+    } else { 
+        printf("Killing server");
+        printf("\n========================================\n");
+    }
+    // Server server thread is then stopped by the destructor
+}
+
+DEFINE_ART_MODULE(CrvDQM)
+}

--- a/otsdaq-mu2e-crv/CMakeLists.txt
+++ b/otsdaq-mu2e-crv/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(FEInterfaces)
+add_subdirectory(ArtModules)

--- a/otsdaq-mu2e-crv/fcl/RunCrvDQM.fcl
+++ b/otsdaq-mu2e-crv/fcl/RunCrvDQM.fcl
@@ -1,0 +1,37 @@
+process_name : CrvDQM
+
+source: {
+  module_type: RootInput # EmptyEvent
+  maxEvents: -1
+}
+services : {
+  message : {
+    destinations : {
+      console : {
+        type : "cout"
+        threshold : "INFO"
+        categories : {
+          default : { limit : 50 }
+        }
+      }
+    }
+  }
+}
+
+physics : {
+  analyzers : {
+    dqm : {
+      module_type : CrvDQM
+      port : 8877 // server port 
+      diagLevel : 1 // debug level
+      onlineRefreshPeriod : 250 // ms
+      keepAlive : 1
+      keepAliveDuration : 1 // mins
+      histColor : "red" // "blue" // "green"
+    }
+  }
+ 
+  dqm_path : [dqm]
+  end_paths : [dqm_path]
+  
+}


### PR DESCRIPTION
Added a standalone CRV web viewer for artdaq fragments. This is supposed to form the basis of an online DQM for the CRV. It uses THttpServer and binds to a local port by default.

<img width="1727" alt="Screenshot 2025-02-10 at 11 23 50" src="https://github.com/user-attachments/assets/65436481-082b-4d11-bafb-a8cd12b84f33" />
