### PR TITLE
Fix the FEB_Registers.h header

### DIFF
--- a/otsdaq-mu2e-crv/FEInterfaces/FEB_Registers.h
+++ b/otsdaq-mu2e-crv/FEInterfaces/FEB_Registers.h
@@ -2,6 +2,7 @@
 #define FEB_REGISTERS_H
 
 // #include <functional>  // std::bind, std::function (if needed)
+#include <cstdint> // uint16_t
 
 namespace FEB
 {

--- a/otsdaq-mu2e-crv/FEInterfaces/FEB_Registers.h
+++ b/otsdaq-mu2e-crv/FEInterfaces/FEB_Registers.h
@@ -2,7 +2,7 @@
 #define FEB_REGISTERS_H
 
 // #include <functional>  // std::bind, std::function (if needed)
-#include <cstdint> // uint16_t
+#include <cstdint>  // uint16_t
 
 namespace FEB
 {


### PR DESCRIPTION
GCC 13 requires `#include <cstdint>` before using any fixed-size integer types (e.g. `uint16_t`)